### PR TITLE
Fix HDF5 time-axis check for MOHID-style time arrays

### DIFF
--- a/src/MOHIDLagrangianPreProcessor/hdf5MetaParser.py
+++ b/src/MOHIDLagrangianPreProcessor/hdf5MetaParser.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
-#    
+#
 #    MIT License
-#    
+#
 #    Copyright (c) 2018 RBCanelas
-#    
+#
 #    Permission is hereby granted, free of charge, to any person obtaining a copy
 #    of this software and associated documentation files (the "Software"), to deal
 #    in the Software without restriction, including without limitation the rights
 #    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 #    copies of the Software, and to permit persons to whom the Software is
 #    furnished to do so, subject to the following conditions:
-#    
+#
 #    The above copyright notice and this permission notice shall be included in all
 #    copies or substantial portions of the Software.
-#    
+#
 #    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 #    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,19 @@ import xarray as xr
 import numpy as np
 import netCDF4 as nc
 
+_EPOCH = datetime(1970, 1, 1)
+
+
+def instantToSeconds(t):
+    # Reduce one time entry to a scalar timestamp. MOHID stores each instant as a
+    # 6-element [Y,M,D,h,m,s] array; already-scalar formats are passed through.
+    a = np.asarray(t).ravel()
+    if a.size == 6:
+        d = datetime(int(a[0]), int(a[1]), int(a[2]), int(a[3]), int(a[4]), int(a[5]))
+        return (d - _EPOCH).total_seconds()
+    return float(a)
+
+
 class hdf5Metadata:
     def __init__(self, fileName, baseTime):
         self.fileName = []
@@ -37,26 +50,35 @@ class hdf5Metadata:
 
         self.fileName = fileName
         self.time = []
-        
+
         ncf = nc.Dataset(fileName, diskless=True, persist=False)
         nch = ncf.groups.get('Time')
         xds = xr.open_dataset(xr.backends.NetCDF4DataStore(nch))
-        
-        time_min = xds['Time_00001']
-        number_of_instants = len(xds)
-        time_max = xds[self.getTimeString(number_of_instants)]
-        
-        for i in range(1, number_of_instants+1):
-            self.time.append(xds[self.getTimeString(i)].data)
-            
+
+        # use only Time_XXXXX datasets, ordered by their numeric suffix
+        time_keys = sorted([k for k in xds.variables if k.startswith('Time_')],
+                           key=lambda k: int(k.split('_')[1]))
+        number_of_instants = len(time_keys)
+        time_min = xds[time_keys[0]]
+        time_max = xds[time_keys[-1]]
+
+        for k in time_keys:
+            self.time.append(xds[k].data)
+
         time_start = time_min.data
         time_end = time_max.data
-        
+
         self.startDate = datetime(int(time_start[0]), int(time_start[1]), int(time_start[2]), int(time_start[3]), int(time_start[4]), int(time_start[5]))
         self.endDate = datetime(int(time_end[0]), int(time_end[1]), int(time_end[2]), int(time_end[3]), int(time_end[4]), int(time_end[5]))
         self.startTime = (self.startDate - baseTime).total_seconds()
         self.endTime = (self.endDate - baseTime).total_seconds()
-        
+
+        xds.close()                      # release the opened datasets
+        try:
+            ncf.close()
+        except RuntimeError:
+            pass
+
     def getTimeString(self, i):
 
         if i > 999:
@@ -107,21 +129,25 @@ class hdf5DimParser:
         time_axis = []
         time_axis_filename = []
         for hdf5_meta in hdf5MetadataList:
-            nsteps = len(hdf5_meta.time)
-            time_axis.append(hdf5_meta.time)
-            time_axis_filename.append([hdf5_meta.fileName for i in range(0, nsteps)])
+            # collapse each [Y,M,D,h,m,s] instant to a scalar so the time axis is 1-D
+            # and stays the same length as the filename axis
+            for t in hdf5_meta.time:
+                time_axis.append(instantToSeconds(t))
+                time_axis_filename.append(hdf5_meta.fileName)
 
         # build one dimension time axis
-        time_axis = np.hstack(time_axis)
-        time_axis_filename = np.hstack(time_axis_filename)
+        time_axis = np.asarray(time_axis, dtype=float)
+        time_axis_filename = np.asarray(time_axis_filename)
 
         print('-> Checking time integrity through files... ')
 
         # test #1: Seek for repeated values.
         # They ill produce gaps -> If exist Return and skip the second test.
-        mask_repeated = (np.array([np.sum(time == time_axis) for time in time_axis])) > 1
-        if np.any(mask_repeated):
+        values, counts = np.unique(time_axis, return_counts=True)
+        repeated_values = values[counts > 1]
+        if repeated_values.size > 0:
             print(' -> There are repeated values in your time axis')
+            mask_repeated = np.isin(time_axis, repeated_values)
             problem_files = time_axis_filename[mask_repeated]
             problem_steps = time_axis[mask_repeated]
             problem_type = ['repeated-values' for i in range(0, len(problem_steps))]
@@ -129,15 +155,18 @@ class hdf5DimParser:
                 print('->', problem_files[idx],'|', problem_steps[idx], '|', problem_type[idx])
             return
 
-        # test #2: Seek for wholes in data. 
+        # test #2: Seek for wholes in data.
+        # sort by time so dt is computed between consecutive timestamps
+        order = np.argsort(time_axis)
+        time_axis = time_axis[order]
+        time_axis_filename = time_axis_filename[order]
         dt = np.diff(time_axis)
-        unique_dt = np.unique(dt)
-        most_repeated_dt = unique_dt[-1] # most common dt value is the last index.
+        unique_dt, counts_dt = np.unique(dt, return_counts=True)
+        most_repeated_dt = unique_dt[np.argmax(counts_dt)] # most common dt value is the most frequent one.
 
         mask_gap = np.zeros_like(dt, dtype=bool)
-        #Seek for values where the 'dt' is NOT the most rcommon 
-        for non_common_values in unique_dt[:-1]:
-            mask_gap[dt == non_common_values] = True
+        #Seek for values where the 'dt' is NOT the most rcommon
+        mask_gap[dt != most_repeated_dt] = True
 
         # Append a value at the end - match dimension with time_axis
         mask_gap = np.append(mask_gap, False)
@@ -150,4 +179,3 @@ class hdf5DimParser:
             for i in range(0, len(problem_files)):
                 print('->', problem_files[i], '|', problem_steps[i], '|', problem_type[i])
             return
-


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2><span>Description</span></h2><p class="isSelectedEnd"><span>Closes #112.</span></p><h2><span>Problem</span></h2><p class="isSelectedEnd"><span>When more than one MOHID-style HDF5 file is passed to the PreProcessor, the time integrity check </span><code dir="ltr"><span>hdf5DimParser.checkTime()</span></code><span> can abort with:</span></p><pre dir="ltr"><code dir="ltr"><span>IndexError: boolean index did not match indexed array along axis 0;
size of axis is 432 but size of corresponding boolean axis is 144</span></code></pre><p class="isSelectedEnd"><span>MOHID HDF5 stores each time instant as a 6-element array:</span></p><pre dir="ltr"><code dir="ltr"><span><span data-placeholder-token="true" class="text-token-text-primary cursor-text rounded-sm">[year, month, day, hour, minute, second]</span></span></code></pre><p class="isSelectedEnd"><span>However, </span><code dir="ltr"><span>checkTime()</span></code><span> assumes that the time axis is a one-dimensional list of scalar timestamps.</span></p><p class="isSelectedEnd"><span>With multiple HDF5 files, </span><code dir="ltr"><span>np.hstack()</span></code><span> is applied to per-file arrays with shape </span><code dir="ltr"><span>(N, 6)</span></code><span>. This concatenates the arrays column-wise, producing a time axis with shape </span><code dir="ltr"><span>(N, 6 * number_of_files)</span></code><span>, while </span><code dir="ltr"><span>time_axis_filename</span></code><span> is built as a flat array with length </span><code dir="ltr"><span>N * number_of_files</span></code><span>.</span></p><p class="isSelectedEnd"><span>For example, with 3 files and 144 time steps per file:</span></p><pre dir="ltr"><code dir="ltr"><span>time_axis.shape          = (144, 18)
time_axis_filename.shape = (432,)
mask_repeated.shape      = (144,)</span></code></pre><p class="isSelectedEnd"><span>The boolean mask is then used to index the filename array:</span></p><pre dir="ltr"><code dir="ltr"><span>problem_files = time_axis_filename<span data-placeholder-token="true" class="text-token-text-primary cursor-text rounded-sm">[mask_repeated]</span></span></code></pre><p class="isSelectedEnd"><span>This causes the </span><code dir="ltr"><span>IndexError</span></code><span>.</span></p><p class="isSelectedEnd"><span>The repeated-value check can also produce false positives because it compares individual integer fields such as year, month, day, hour, minute, and second, instead of comparing complete timestamps.</span></p><p class="isSelectedEnd"><span>The NetCDF path (</span><code dir="ltr"><span>ncMetaParser</span></code><span>) is not affected because its time values are already represented as a one-dimensional scalar array.</span></p><h2><span>Fix</span></h2><p class="isSelectedEnd"><span>This PR converts each HDF5 time instant to a scalar timestamp before building the time axis used by </span><code dir="ltr"><span>checkTime()</span></code><span>.</span></p><p class="isSelectedEnd"><span>The change is intended to be conservative and backward-compatible:</span></p><ul data-spread="false"><li><span>Add a helper to convert 6-element </span><code dir="ltr"><span><span data-placeholder-token="true" class="text-token-text-primary cursor-text rounded-sm">[year, month, day, hour, minute, second]</span></span></code><span> arrays to scalar seconds.</span></li><li><span>Keep already-scalar time values supported.</span></li><li><span>Build </span><code dir="ltr"><span>time_axis</span></code><span> and </span><code dir="ltr"><span>time_axis_filename</span></code><span> as aligned one-dimensional arrays.</span></li><li><span>Detect repeated timestamps using complete scalar timestamps via </span><code dir="ltr"><span>np.unique(..., return_counts=True)</span></code><span>.</span></li><li><span>Sort timestamps before checking time gaps.</span></li><li><span>Use the most frequent time step for the gap check, instead of the largest unique value.</span></li></ul><p class="isSelectedEnd"><span>Minor robustness improvements are also included:</span></p><ul data-spread="false"><li><span>Read only </span><code dir="ltr"><span>Time_XXXXX</span></code><span> datasets and order them by their numeric suffix.</span></li><li><span>Explicitly close opened NetCDF/xarray datasets.</span></li></ul><p class="isSelectedEnd"><span>The public interface is unchanged.</span></p><h2><span>Testing</span></h2><p class="isSelectedEnd"><span>Tested with MOHID-style HDF5 daily split files.</span></p>
Input | Before | After
-- | -- | --
3 files, no duplicate timestamps | IndexError | passes
3 files sharing a midnight timestamp | IndexError | correctly reports duplicate timestamps
single file | passes | passes

<p class="isSelectedEnd"><span>This fixes the crash and false repeated-value detection while preserving the ability to detect genuine duplicate timestamps.</span></p><h2><span>Notes</span></h2><ul data-spread="false"><li><span>No changes were made to the model body.</span></li><li><span>The issue was reproduced with MOHID-Lagrangian v26.03.</span></li></ul><!--EndFragment-->
</body>
</html>