### PR TITLE
Fix tracer emission count for instantaneous and continuous sources

### DIFF
--- a/src/MOHIDLagrangianLib/emitter.f90
+++ b/src/MOHIDLagrangianLib/emitter.f90
@@ -69,9 +69,8 @@
     class(*), pointer :: aSource
     type(string) :: outext
     integer :: i
-    logical :: reset_stack
+    integer :: n_emitted
 
-    reset_stack = .false.
     call srclist%reset()                   ! reset list iterator
     do while(srclist%moreValues())         ! loop while there are values
         aSource => srclist%currentValue()  ! get current value
@@ -86,13 +85,16 @@
                     endif
                 endif
                 aSource%now%emission_stack = aSource%now%emission_stack + aSource%par%emitting_rate*Globals%SimDefs%dt  !adding to the emission stack
-                do i=1, floor(aSource%now%emission_stack)
+                !small epsilon absorbs floating-point round-down (e.g. (1/60*31)*60 = 30.999...)
+                n_emitted = floor(aSource%now%emission_stack + 1.0d-9)
+                do i=1, n_emitted
                     call self%emitt_src(aSource, trclist)
-                    reset_stack = .true.                    
-                end do 
-                if (reset_stack) then
-                    aSource%now%emission_stack = 0 !reseting for the next time step              
-                end if
+                end do
+                !subtract what was emitted instead of resetting to zero: keeps the fractional
+                !remainder so slow continuous rates emit the exact requested total over time
+                !(the old reset also zeroed the stack of every following source in the list
+                ! once any source had emitted, via the shared reset_stack flag)
+                aSource%now%emission_stack = aSource%now%emission_stack - n_emitted
             end if
             class default
             outext = '[Emitter] Unexepected type of content, not a Source'

--- a/src/MOHIDLagrangianLib/sources.f90
+++ b/src/MOHIDLagrangianLib/sources.f90
@@ -554,7 +554,7 @@
     !Setting state variables
     src%now%age=0.0
     src%now%active=.false. !disabled by default
-    src%now%emission_stack = 1
+    src%now%emission_stack = 0 !start empty: an initial value of 1 emitted one extra (seed) tracer on the first emission step, so every source produced requested+1 tracers
     src%now%pos=src%par%geometry%pt !coords of the Source (meaning depends on the geometry type!)
     !setting statistical samplers
     src%stats%particles_emitted=0


### PR DESCRIPTION
Hello, and thank you for maintaining MOHID-Lagrangian — we use it operationally
for drift forecasting in Korea. While validating emission counts we found three
small issues in the emitter and would like to propose a fix.

## Issues

1. `emission_stack` starts at 1 (`sources.f90`), so every source emits one
   extra tracer on its first emission step (requesting N yields N+1).
2. After emitting, the stack is reset to 0 (`emitter.f90`), discarding the
   fractional remainder. Continuous sources with fractional per-step rates
   under-emit systematically — e.g. requesting 3000 tracers over 72 h
   produced 2160.
3. The shared `reset_stack` flag is never cleared between sources, so one
   source emitting also zeroes the accumulated stack of the following
   sources in the list.

## Proposed fix

- Start `emission_stack` at 0, and subtract the emitted count after each
  emission instead of resetting to zero, so the fractional remainder is
  preserved and the cumulative total converges to `rate × time` exactly.
  This also removes the `reset_stack` flag (and issue 3 with it).
- A small epsilon (1e-9) inside `floor()` absorbs floating-point round-down
  of `emitting_rate*dt`, which would otherwise emit N-1 for some N.

## Validation

Tested on two independent builds (gfortran and ifort): instantaneous requests
of 1–5000 tracers now match exactly for every N, and continuous windows of
3–72 h emit exactly the requested totals (previously N+1 and −28%
respectively). Drift/beaching regression runs show no behavioural change
other than the corrected counts.

Happy to adjust anything — thank you for taking a look!